### PR TITLE
Run DELETE on expired session based on a timed check instead of a random factor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ app.use(session({
 * **conString** - if you don't have your PostgreSQL connection string in the `DATABASE_URL` environment variable (as you do by default on eg. Heroku) – then you need to specify the connection [string or object](https://github.com/brianc/node-postgres/wiki/pg#connectstring-connectionstring-function-callback) here so that this module that create new connections. Needen even if you supply your own database module.
 * **schemaName** - if your session table is in another Postgres schema than the default (it normally isn't), then you can specify that here.
 * **tableName** - if your session table is named something else than `session`, then you can specify that here.
+* **expiryMethod** - defines how the checks for expired session will be made. defaults to `random` can also be `timed`.
+* **randomFactor** - used along with  `expiryMethod : "random"`. May be Any floating number between 0 and 1. A value of 0.8 means the expiry cleanup will run on 80% (or so) of the requests.
+* **timedExpiryDelay** - used along with  `expiryMethod : "timed"`. Sets a minimum delay in seconds at which the expiry check will run. Each time a request is made, the `last execution time` + `timedExpiryDelay` will decide if expiry check runs.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ app.use(session({
 * **schemaName** - if your session table is in another Postgres schema than the default (it normally isn't), then you can specify that here.
 * **tableName** - if your session table is named something else than `session`, then you can specify that here.
 * **expiryMethod** - defines how the checks for expired session will be made. defaults to `random` can also be `timed`.
-* **randomFactor** - used along with  `expiryMethod : "random"`. May be Any floating number between 0 and 1. A value of 0.8 means the expiry cleanup will run on 80% (or so) of the requests.
+* **randomExpiryFactor** - used along with  `expiryMethod : "random"`. May be Any floating number between 0 and 1. A value of 0.8 means the expiry cleanup will run on 80% (or so) of the requests.
 * **timedExpiryDelay** - used along with  `expiryMethod : "timed"`. Sets a minimum delay in seconds at which the expiry check will run. Each time a request is made, the `last execution time` + `timedExpiryDelay` will decide if expiry check runs.
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -69,9 +69,7 @@ app.use(session({
 * **conString** - if you don't have your PostgreSQL connection string in the `DATABASE_URL` environment variable (as you do by default on eg. Heroku) – then you need to specify the connection [string or object](https://github.com/brianc/node-postgres/wiki/pg#connectstring-connectionstring-function-callback) here so that this module that create new connections. Needen even if you supply your own database module.
 * **schemaName** - if your session table is in another Postgres schema than the default (it normally isn't), then you can specify that here.
 * **tableName** - if your session table is named something else than `session`, then you can specify that here.
-* **expiryMethod** - defines how the checks for expired session will be made. defaults to `random` can also be `timed`.
-* **randomExpiryFactor** - used along with  `expiryMethod : "random"`. May be Any floating number between 0 and 1. A value of 0.8 means the expiry cleanup will run on 80% (or so) of the requests.
-* **timedExpiryDelay** - used along with  `expiryMethod : "timed"`. Sets a minimum delay in seconds at which the expiry check will run. Each time a request is made, the `last execution time` + `timedExpiryDelay` will decide if expiry check runs.
+* **pruneSessionInterval** - Sets the delay in seconds at which expired sessions are pruned from the database. Default is 60 seconds.
 
 ## Changelog
 

--- a/index.js
+++ b/index.js
@@ -47,9 +47,6 @@ module.exports = function (session) {
         if (err){
           console.warn ("failed to prune sessions");
           console.log(err);
-        }else{
-          console.log("prune session done");
-          console.log(arguments[1]);
         }
 
         this.isPruningSessions = false;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function (session) {
     , PGStore;
 
   PGStore = function (options) {
-    var _this = this;
+    var self = this;
 
     options = options || {};
     Store.call(this, options);
@@ -24,7 +24,7 @@ module.exports = function (session) {
     this.pruneSessions(); // clean on instanciation
 
     setInterval(function(){
-      _this.pruneSessions();
+      self.pruneSessions();
     },this.pruneSessionInterval);
   };
 
@@ -40,16 +40,15 @@ module.exports = function (session) {
    */
 
   PGStore.prototype.pruneSessions = function(){
+    var self = this;
     if (!this.isPruningSessions){
       this.isPruningSessions = true;
       this.query('DELETE FROM ' + this.quotedTable() + ' WHERE expire < NOW()',function(err){
-
+        self.isPruningSessions = false;
         if (err){
           console.warn ("failed to prune sessions");
           console.log(err);
         }
-
-        this.isPruningSessions = false;
       });
     }else{
       console.warn ("Session pruning is already running. You might want to check isPruningSessions before calling pruneSessions(), or increase 'pruneSessionInterval' to avoid concurrent executions.");


### PR DESCRIPTION
Since the random method is based on a random factor match per request, more requests means more expiry checks in the database. Since expiry is based on time, I though it would make sense to base the checks frequency on a timed delay instead. This was added as an option, defaulting to the original random factor checks. I've also updated the readme to reflect my changes.