### PR TITLE
Unbreak schema name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ app.use(session({
 
 ## Changelog
 
+### 2.3.0
+
+* Backwards compatibility: No longer defaults to a `public` schema, as was done in `2.2.0`, but rather defaults to pre-2.2.0 behavior to restor backwards compatibility with `2.x` version as required by Semamtic Versioning
+
 ### 2.2.1
 
 * Hotfix: Update `require('pg')` to match package.json, thanks for reporting @dmitriiabramov

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function (session) {
     options = options || {};
     Store.call(this, options);
 
-    this.schemaName = options.schemaName || 'public';
+    this.schemaName = options.schemaName || null;
     this.tableName = options.tableName || 'session';
 
     this.conString = options.conString || process.env.DATABASE_URL;
@@ -36,7 +36,13 @@ module.exports = function (session) {
    */
 
   PGStore.prototype.quotedTable = function () {
-    return '"' + this.schemaName + '"."' + this.tableName + '"';
+    var result = '"' + this.tableName + '"';
+
+    if (this.schemaName) {
+      result = '"' + this.schemaName + '".' + result;
+    }
+
+    return result;
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "prepush": "npm test"
   },
   "devDependencies": {
+    "chai": "^2.1.1",
     "grunt": "^0.4.5",
     "husky": "^0.6.2",
     "istanbul": "^0.3.7",
     "lintlovin": "^1.14.0",
-    "mocha": "^2.1.0"
+    "mocha": "^2.1.0",
+    "sinon": "^1.13.0"
   }
 }

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -1,0 +1,75 @@
+/* jshint node: true */
+/* global beforeEach, afterEach, describe, it */
+
+'use strict';
+
+var chai = require('chai');
+var sinon = require('sinon');
+
+chai.should();
+
+describe('PGStore', function () {
+  var connectPgSimple = require('../'),
+    PGStore,
+    clientExcpectation,
+    pgStub,
+    options;
+
+  beforeEach(function () {
+    PGStore = connectPgSimple({
+      Store: sinon.stub()
+    });
+
+    clientExcpectation = sinon.expectation.create('pgClient').never();
+
+    pgStub = {
+      connect: sinon.stub().returns({
+        client: clientExcpectation,
+      })
+    };
+
+    options = {
+      pg: pgStub,
+      pruneSessionInterval: false
+    };
+  });
+
+  afterEach(function () {
+    clientExcpectation.verify();
+  });
+
+  describe('quotedTable', function () {
+
+    it('should not include a schema by default', function () {
+      (new PGStore(options)).quotedTable().should.be.a('string').that.equals('"session"');
+    });
+
+    it('should have an overrideable table', function () {
+      options.tableName = 'foobar';
+      (new PGStore(options)).quotedTable().should.be.a('string').that.equals('"foobar"');
+    });
+
+    it('should have a definable schema', function () {
+      options.schemaName = 'barfoo';
+      (new PGStore(options)).quotedTable().should.be.a('string').that.equals('"barfoo"."session"');
+    });
+
+    it('should accept custom schema and table', function () {
+      options.tableName = 'foobar';
+      options.schemaName = 'barfoo';
+      (new PGStore(options)).quotedTable().should.be.a('string').that.equals('"barfoo"."foobar"');
+    });
+
+    it('should accept legacy definition of schemas', function () {
+      options.tableName = 'barfoo"."foobar';
+      (new PGStore(options)).quotedTable().should.be.a('string').that.equals('"barfoo"."foobar"');
+    });
+
+    it('should not care about dots in names', function () {
+      options.tableName = 'barfoo.foobar';
+      (new PGStore(options)).quotedTable().should.be.a('string').that.equals('"barfoo.foobar"');
+    });
+
+  });
+
+});


### PR DESCRIPTION
As pointed out in #14 there was an unintended breaking change introduced in 2.2.0. This PR tries to fix that + add tests to ensure the same thing doesn't unintentionally break again.

As the linting + testing code was added on top of the branch that solves #13 this PR currently includes the changes from there as well, when those merges those commits will disappear from here.