### PR TITLE
Support for SailsJS (Express 3 apps)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var oneDay = 86400;
 
 module.exports = function (session) {
 
-  var Store = session.Store,
+  var Store = session.Store || session.session.Store,
     PGStore;
 
   PGStore = function (options) {


### PR DESCRIPTION
For example, SailsJS (http://sailsjs.org/) uses Express 3.x and with this fix you can use
node-connect-pg-simple for sessions adapter with SailsJS