### PR TITLE
Bugfix: errors not propagated

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ module.exports = function (session) {
     const query = 'INSERT INTO ' + this.quotedTable() + ' (sess, expire, sid) SELECT $1, to_timestamp($2), $3 ON CONFLICT (sid) DO UPDATE SET sess=$1, expire=to_timestamp($2) RETURNING sid';
 
     this.query(query, [sess, expireTime, sid], function (err) {
-      if (fn) { fn.apply(this, err); }
+      if (fn) { fn.call(this, err); }
     });
   };
 

--- a/index.js
+++ b/index.js
@@ -2,10 +2,33 @@
 
 const util = require('util');
 const oneDay = 86400;
+const pgVersionMin = { major: 9, minor: 5 };
 
 const currentTimestamp = function () {
   return Math.ceil(Date.now() / 1000);
 };
+
+// Define all queries to the databse here.  The $TABLE will be
+// replaced during initialization, with a propperly quoted value.
+const SQL = Object.freeze({
+  setup:
+    'SELECT version(), quote_ident($1) AS schema, quote_ident($2) AS table',
+  set:
+    'INSERT INTO $TABLE (sess, expire, sid) ' +
+    'SELECT $1, to_timestamp($2), $3 ' +
+    'ON CONFLICT (sid) DO ' + // Needs Postgrsql 9.5 or later for ON CONFLICT DO
+    'UPDATE SET sess=$1, expire=to_timestamp($2) ' +
+    'RETURNING sid',
+  prune:
+    'DELETE FROM $TABLE WHERE expire < to_timestamp($1)',
+  touch:
+    'UPDATE $TABLE SET expire = to_timestamp($1) ' +
+    'WHERE sid = $2 RETURNING sid',
+  destroy:
+    'DELETE FROM $TABLE WHERE sid = $1',
+  get:
+    'SELECT sess FROM $TABLE WHERE sid = $1 AND expire >= to_timestamp($2)'
+});
 
 module.exports = function (session) {
   const Store = session.Store || session.session.Store;
@@ -49,14 +72,46 @@ module.exports = function (session) {
       this.ownsPg = true;
     }
 
-    if (options.pruneSessionInterval === false) {
-      this.pruneSessionInterval = false;
-    } else {
-      this.pruneSessionInterval = (options.pruneSessionInterval || 60) * 1000;
-      setImmediate(function () {
-        this.pruneSessions();
-      }.bind(this));
-    }
+    // Calling quote_ident on schemaName and tableName will propperly
+    // quote them if needed. Embedded quotes are properly doubled.
+
+    this.query(SQL.setup, [this.schemaName, this.tableName], (err, res) => {
+      if (err) return this.errorLog(err);
+      // Extract major and minor version from string
+      let ver = /\s(\d+)\.(\d+)/.exec(res.version);
+      if (!ver) {
+        this.errorLog(Error('Could not get server version'));
+      } else {
+        const min = pgVersionMin;
+        ver = {
+          major: parseInt(ver[1]),
+          minor: parseInt(ver[2])
+        };
+        if (ver.major < min.major || (ver.major === min.major && ver.minor < min.minor)) {
+          this.errorLog(Error(
+            `Too old version of postgresql. Need ${min.major}.${min.minor} or later.`
+          ));
+        }
+      }
+
+      // Concatenate schema and table name.
+      const fqname = (res.schema ? res.schema + '.' : '') + res.table;
+      // Replace $TABLE in query strings with the correct value.
+      this.SQL = Object.keys(SQL).reduce(function (out, key) {
+        out[key] = SQL[key].replace(/\$TABLE/g, fqname);
+        return out;
+      }, {});
+      this.SQL = Object.freeze(this.SQL);
+
+      if (options.pruneSessionInterval === false) {
+        this.pruneSessionInterval = false;
+      } else {
+        this.pruneSessionInterval = (options.pruneSessionInterval || 60) * 1000;
+        setImmediate(function () {
+          this.pruneSessions();
+        }.bind(this));
+      }
+    });
   };
 
   /**
@@ -94,7 +149,7 @@ module.exports = function (session) {
    */
 
   PGStore.prototype.pruneSessions = function (fn) {
-    this.query('DELETE FROM ' + this.quotedTable() + ' WHERE expire < to_timestamp($1)', [currentTimestamp()], function (err) {
+    this.query(this.SQL.prune, [currentTimestamp()], function (err) {
       if (fn && typeof fn === 'function') {
         return fn(err);
       }
@@ -111,23 +166,6 @@ module.exports = function (session) {
         this.pruneTimer.unref();
       }
     }.bind(this));
-  };
-
-  /**
-   * Get the quoted table.
-   *
-   * @return {String} the quoted schema + table for use in queries
-   * @access private
-   */
-
-  PGStore.prototype.quotedTable = function () {
-    let result = '"' + this.tableName + '"';
-
-    if (this.schemaName) {
-      result = '"' + this.schemaName + '".' + result;
-    }
-
-    return result;
   };
 
   /**
@@ -182,7 +220,7 @@ module.exports = function (session) {
    */
 
   PGStore.prototype.get = function (sid, fn) {
-    this.query('SELECT sess FROM ' + this.quotedTable() + ' WHERE sid = $1 AND expire >= to_timestamp($2)', [sid, currentTimestamp()], function (err, data) {
+    this.query(this.SQL.get, [sid, currentTimestamp()], function (err, data) {
       if (err) { return fn(err); }
       if (!data) { return fn(); }
       try {
@@ -204,9 +242,7 @@ module.exports = function (session) {
 
   PGStore.prototype.set = function (sid, sess, fn) {
     const expireTime = this.getExpireTime(sess.cookie.maxAge);
-    const query = 'INSERT INTO ' + this.quotedTable() + ' (sess, expire, sid) SELECT $1, to_timestamp($2), $3 ON CONFLICT (sid) DO UPDATE SET sess=$1, expire=to_timestamp($2) RETURNING sid';
-
-    this.query(query, [sess, expireTime, sid], function (err) {
+    this.query(this.SQL.set, [sess, expireTime, sid], function (err) {
       if (fn) { fn.call(this, err); }
     });
   };
@@ -219,7 +255,7 @@ module.exports = function (session) {
    */
 
   PGStore.prototype.destroy = function (sid, fn) {
-    this.query('DELETE FROM ' + this.quotedTable() + ' WHERE sid = $1', [sid], function (err) {
+    this.query(this.SQL.destroy, [sid], function (err) {
       if (fn) { fn(err); }
     });
   };
@@ -235,12 +271,7 @@ module.exports = function (session) {
 
   PGStore.prototype.touch = function (sid, sess, fn) {
     const expireTime = this.getExpireTime(sess.cookie.maxAge);
-
-    this.query(
-      'UPDATE ' + this.quotedTable() + ' SET expire = to_timestamp($1) WHERE sid = $2 RETURNING sid',
-      [expireTime, sid],
-      function (err) { fn(err); }
-    );
+    this.query(this.SQL.touch, [expireTime, sid], function (err) { fn(err); });
   };
 
   return PGStore;


### PR DESCRIPTION
Changed
  fn.apply(this, err);
to
  fn.call(this, err)
in
  PGStore.prototype.set

The apply() method calls a function with a given this value, and
arguments provided as an array (or an array-like object).

The call() method calls a function with a given this value and arguments
provided individually.

Using apply with the err object does not propagate the error:
The callback will see undefined, and no error will be shown.

I spent two hours trying to figure out why the module din't work.
Turns out that I was connection to an too old version of postgres
that don't have ON CONCFLICT. Because of this bug the error
was not propagated.

After this change the error will be shown on the console.