### PR TITLE
Bugfix: errors not propagated

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ module.exports = function (session) {
     const query = 'INSERT INTO ' + this.quotedTable() + ' (sess, expire, sid) SELECT $1, to_timestamp($2), $3 ON CONFLICT (sid) DO UPDATE SET sess=$1, expire=to_timestamp($2) RETURNING sid';
 
     this.query(query, [sess, expireTime, sid], function (err) {
-      if (fn) { fn.apply(this, err); }
+      if (fn) { fn.call(this, err); }
     });
   };
 


### PR DESCRIPTION
Changed
  fn.apply(this, err);
to
  fn.call(this, err)
in
  PGStore.prototype.set

The apply() method calls a function with a given this value, and
arguments provided as an array (or an array-like object).

The call() method calls a function with a given this value and arguments
provided individually.

Using apply with the err object does not propagate the error:
The callback will see undefined, and no error will be shown.

(I spent two hours trying to figure out why the module din't work.
Turns out that I was connection to an too old version of postgres
that don't have ON CONCFLICT. Because of this bug the error
was not propagated.)

After this change the error will be shown on the console.