### PR TITLE
Import + update typings from DefinitelyTyped

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,42 @@
+// Type definitions for connect-pg-simple 4.2
+// Project: https://github.com/voxpelli/node-connect-pg-simple#readme
+// Definitions by: Pasi Eronen <https://github.com/pasieronen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import { RequestHandler } from "express";
+import { Store, SessionOptions } from "express-session";
+import { Pool, PoolConfig } from "pg";
+import { Session } from 'inspector';
+
+export default function connectPgSimple(session: (options?: SessionOptions) => RequestHandler): typeof PGStore;
+
+declare class PGStore extends Store {
+  constructor(options?: PGStoreOptions);
+
+  close(): void;
+  pruneSessions(callback?: (err: Error) => void): void;
+
+  private quotedTable(): string;
+  private getExpireTime(maxAge?: number): number;
+  private query(query: string, params?: any[], callback?: (err: Error) => void): void;
+  private query(query: string, callback?: (err: Error) => void): void;
+
+  get(sid: string, callback: (err: Error) => void): void;
+  set(sid: string, session: SessionData, callback?: (err: Error) => void): void;
+  destroy(sid: string, callback?: (err: Error) => void): void;
+  touch(sid: string, session: SessionData, callback?: (err: Error) => void): void;
+}
+
+interface PGStoreOptions {
+  pool?: Pool;
+  pgPromise?: object; // not typed to avoid dependency to "pg-promise" module (which includes its own types)
+  conString?: string;
+  conObject?: PoolConfig;
+  ttl?: number;
+  schemaName?: string;
+  tableName?: string;
+  pruneSessionInterval?: false | number;
+  // tslint:disable-next-line:prefer-method-signature
+  errorLog?: (...args: any[]) => void;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.0.1",
   "description": "A simple, minimal PostgreSQL session store for Connect/Express",
   "url": "http://github.com/voxpelli/node-connect-pg-simple",
+  "typings": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/voxpelli/node-connect-pg-simple.git"


### PR DESCRIPTION
`express-session` is [getting new typings](https://github.com/expressjs/session/pull/656) that are incompatible with the current ones on DefinitelyTyped.

The current DefinitelyTyped typings out of date and frankly unusable. To fix this I created new typings, but since DefinitelyTyped is a mess and it's generally preferable to include typings directly in the package I'm creating the PR here.

To make sure these definitions stay compatibly with `express-session` we should probably wait until [express-session/#656](https://github.com/expressjs/session/pull/656) (new definitions) is either merged or rejected. If it's merged I'll make this definition compatible with the new, improved and included `express-session` definitions rather than the outdated (and wrong) definitions from DT.