### PR TITLE
Fix of error/callback checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,7 +303,6 @@ module.exports = function (session) {
 
       this.query(query, [sess, expireTime, sid], function (err) {
         if (fn) { fn(err); }
-        fn();
       });
     }
 


### PR DESCRIPTION
Checking if fn is defined and then calling fn() if it is not seems to be an unintended behavior. The alternative to this edit would be to check if err is defined and then keep the fn() call below.