### PR TITLE
log whole error object instead of only message

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ module.exports = function (session) {
         }
         this.#pool = new (require('pg')).Pool(conObject);
         this.#pool.on('error', err => {
-          this.#errorLog('PG Pool error:', err.message);
+          this.#errorLog('PG Pool error:', err);
         });
         this.#ownsPg = true;
       }
@@ -256,7 +256,7 @@ module.exports = function (session) {
         }
 
         if (err) {
-          this.#errorLog('Failed to prune sessions:', err.message);
+          this.#errorLog('Failed to prune sessions:', err);
         }
 
         this.#clearPruneTimer();


### PR DESCRIPTION
Without doing this error messages stack trace is lost when it's very important to be able to debug errors.

as type of errorLog  is `typeof console.error` this shouldn't be a breaking of current api as clients are responsible to handle any arguments