### PR TITLE
use consistent spaces in sql file

### DIFF
--- a/table.sql
+++ b/table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE "session" (
   "sid" varchar NOT NULL COLLATE "default",
-	"sess" json NOT NULL,
-	"expire" timestamp(6) NOT NULL
+  "sess" json NOT NULL,
+  "expire" timestamp(6) NOT NULL
 )
 WITH (OIDS=FALSE);
 


### PR DESCRIPTION
`sid` had prefix of 2 spaces while `sess` and `expire` had one tab.
now all have 2 spaces as prefix