### PR TITLE
Allow customization of the column names

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm test
+#npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-#npm test
+npm test

--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ Listed in the order they will be picked up. If multiple are defined, then the fi
 * **createTableIfMissing** - if set to `true` then creates the table in the case where the table does not already exist. Defaults to `false`.
 * **disableTouch** – boolean value that if set to `true` disables the updating of TTL in the database when using touch. Defaults to false.
 * **schemaName** - if your session table is in another Postgres schema than the default (it normally isn't), then you can specify that here.
-* **tableName** - if your session table is named something else than `session`, then you can specify that here.
+* **tableName** - if your session table is named something other than `session`, then you can specify that here.
+* **sidColumnName** - if your sid column is named something other than `sid`, then you can specify that here.
+* **sessColumnName** - if your sess column is named something other than `sess`, then you can specify that here.
+* **expireColumnName** - if your expire column is named something other than `expire`, then you can specify that here.
 * **pruneSessionInterval** - sets the delay in seconds at which expired sessions are pruned from the database. Default is `60` seconds. If set to `false` no automatic pruning will happen. By default every delay is randomized between 50% and 150% of set value, resulting in an average delay equal to the set value, but spread out to even the load on the database. Automatic pruning will happen `pruneSessionInterval` seconds after the last pruning (includes manual prunes).
 * **pruneSessionRandomizedInterval** – if set to `false`, then the exact value of `pruneSessionInterval` will be used in all delays. No randomization will happen. If multiple instances all start at once, disabling randomization can mean that multiple instances are all triggering pruning at once, causing unnecessary load on the database. Can also be set to a method, taking a numeric `delay` parameter and returning a modified one, thus allowing a custom delay algorithm if wanted.
 * **errorLog** – the method used to log errors in those cases where an error can't be returned to a callback. Defaults to `console.error()`, but can be useful to override if one eg. uses [Bunyan](https://github.com/trentm/node-bunyan) for logging.

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ const unescapePgIdentifier = (value) => value.replace(/""/g, '"');
 
 /** @typedef {(err: Error|null) => void} SimpleErrorCallback */
 
-/** @typedef {{ cookie: { maxAge?: number, expire?: number, [property: string]: any }, [property: string]: any }} SessionObject */
+/** @typedef {{ cookie: { maxAge?: number, expires?: number, [property: string]: any }, [property: string]: any }} SessionObject */
 
 /** @typedef {(delay: number) => number} PGStorePruneDelayRandomizer */
 /** @typedef {Object<string, any>} PGStoreQueryResult */
@@ -394,7 +394,7 @@ module.exports = function (session) {
      * @access public
      */
     get (sid, fn) {
-      this.query('SELECT ' + this.sessColumn() + ' FROM ' + this.quotedTable() + ' WHERE ' + this.sidColumn() + ' = $1 AND expire >= to_timestamp($2)', [sid, currentTimestamp()], (err, data) => {
+      this.query('SELECT ' + this.sessColumn() + ' FROM ' + this.quotedTable() + ' WHERE ' + this.sidColumn() + ' = $1 AND ' + this.expireColumn() + ' >= to_timestamp($2)', [sid, currentTimestamp()], (err, data) => {
         if (err) { return fn(err); }
         // eslint-disable-next-line unicorn/no-null
         if (!data) { return fn(null); }

--- a/index.js
+++ b/index.js
@@ -44,6 +44,12 @@ const currentTimestamp = () => Math.ceil(Date.now() / 1000);
  */
 const escapePgIdentifier = (value) => value.replace(/"/g, '""');
 
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+const unescapePgIdentifier = (value) => value.replace(/""/g, '"');
+
 /** @typedef {(err: Error|null) => void} SimpleErrorCallback */
 
 /** @typedef {{ cookie: { maxAge?: number, expire?: number, [property: string]: any }, [property: string]: any }} SessionObject */
@@ -394,7 +400,7 @@ module.exports = function (session) {
         if (!data) { return fn(null); }
         try {
           // eslint-disable-next-line unicorn/no-null
-          return fn(null, (typeof data['sess'] === 'string') ? JSON.parse(data['sess']) : data['sess']);
+          return fn(null, (typeof data[unescapePgIdentifier(this.sessColumnName)] === 'string') ? JSON.parse(data[unescapePgIdentifier(this.sessColumnName)]) : data[unescapePgIdentifier(this.sessColumnName)]);
         } catch {
           return this.destroy(sid, fn);
         }

--- a/test/integration/express.spec.js
+++ b/test/integration/express.spec.js
@@ -141,7 +141,7 @@ describe('Express', () => {
 
         await agent.get('/');
 
-        const firstResult = await queryPromise('SELECT extract(epoch from expire) AS expire FROM session');
+        const firstResult = await queryPromise('SELECT extract(epoch from expire)::int AS expire FROM session');
         firstResult.should.have.property('rows').that.has.length(1)
           .with.nested.property('[0].expire').that.is.a('number');
 
@@ -149,7 +149,7 @@ describe('Express', () => {
 
         await agent.get('/').expect(200);
 
-        const secondResult = await queryPromise('SELECT extract(epoch from expire) AS expire FROM session');
+        const secondResult = await queryPromise('SELECT extract(epoch from expire)::int AS expire FROM session');
         secondResult.should.have.property('rows').that.has.length(1)
           .with.nested.property('[0].expire').that.is.a('number');
 
@@ -168,7 +168,7 @@ describe('Express', () => {
 
         await agent.get('/');
 
-        const firstResult = await queryPromise('SELECT extract(epoch from expire) AS expire FROM session');
+        const firstResult = await queryPromise('SELECT extract(epoch from expire)::int AS expire FROM session');
         firstResult.should.have.property('rows').that.has.length(1)
           .with.nested.property('[0].expire').that.is.a('number');
 
@@ -176,7 +176,7 @@ describe('Express', () => {
 
         await agent.get('/').expect(200);
 
-        const secondResult = await queryPromise('SELECT extract(epoch from expire) AS expire FROM session');
+        const secondResult = await queryPromise('SELECT extract(epoch from expire)::int AS expire FROM session');
         secondResult.should.have.property('rows').that.has.length(1)
           .with.nested.property('[0].expire').that.is.a('number');
 

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -218,6 +218,27 @@ describe('PGStore', () => {
     });
   });
 
+  describe('sidColumn', () => {
+    it('should escape sid column name', () => {
+      options.sidColumnName = 'foo"ba"r';
+      (new PGStore(options)).sidColumn().should.be.a('string').that.equals('"foo""ba""r"');
+    });
+  });
+
+  describe('sessColumn', () => {
+    it('should escape sess column name', () => {
+      options.sessColumnName = 'foo"ba"r';
+      (new PGStore(options)).sessColumn().should.be.a('string').that.equals('"foo""ba""r"');
+    });
+  });
+
+  describe('expireColumn', () => {
+    it('should escape expire column name', () => {
+      options.expireColumnName = 'foo"ba"r';
+      (new PGStore(options)).expireColumn().should.be.a('string').that.equals('"foo""ba""r"');
+    });
+  });
+
   describe('configSetup', () => {
     /** @type {import('sinon').SinonStub} */
     let poolStub;


### PR DESCRIPTION
I want to use my own column names, but this module uses hardcoded column names.

With this modification, you should be able to pass a custom `sidColumnName`, `sessColumnName`, or `expireColumnName`.

No one should be passing in column names from unsanitized input, so I don't think that SQL injections are an issue.

I only modified some of the tests because PostgreSQL seems to be returning the numbers as strings without an explicit type cast.

Code Example:
```js
app.use(session({
  store: new pgSession({
    pool: pgPool,
    sidColumnName: "sessionID",
    sessColumnName: "session",
    expireColumnName: "expires"
  }),
  secret: process.env.COOKIE_SECRET,
  cookie: {maxAge: 1000 * 60 * 60 * 24},
  resave: false,
  saveUninitialized: false
}))
```