### PR TITLE
Initialize pruning lazily

### DIFF
--- a/test/integration/express.spec.js
+++ b/test/integration/express.spec.js
@@ -130,7 +130,7 @@ describe('Express', () => {
 
     describe('touching', () => {
       it('should update expiry dates on existing sessions when rolling is set', async () => {
-        const clock = sinon.useFakeTimers({ now: 1483228800000 });
+        const clock = sinon.useFakeTimers({ now: 1483228800000, shouldClearNativeTimers: true });
 
         store = new (connectPgSimple(session))({ conObject });
 
@@ -157,7 +157,7 @@ describe('Express', () => {
       });
 
       it('should not update expiry dates on existing sessions when disableTouch is set', async () => {
-        const clock = sinon.useFakeTimers({ now: 1483228800000 });
+        const clock = sinon.useFakeTimers({ now: 1483228800000, shouldClearNativeTimers: true });
 
         store = new (connectPgSimple(session))({ conObject, disableTouch: true });
 
@@ -190,7 +190,7 @@ describe('Express', () => {
       const app = appSetup(store);
       const agent = request.agent(app);
 
-      const clock = sinon.useFakeTimers(Date.now());
+      const clock = sinon.useFakeTimers({ now: Date.now(), shouldClearNativeTimers: true });
 
       return queryPromise('SELECT COUNT(sid) FROM session')
         .should.eventually.have.nested.property('rows[0].count', '0')

--- a/test/integration/pgpromise.spec.js
+++ b/test/integration/pgpromise.spec.js
@@ -91,7 +91,7 @@ describe('pgPromise', () => {
       const app = appSetup(store);
       const agent = request.agent(app);
 
-      const clock = sinon.useFakeTimers(Date.now());
+      const clock = sinon.useFakeTimers({ now: Date.now(), shouldClearNativeTimers: true });
 
       return queryPromise('SELECT COUNT(sid) FROM session')
         .should.eventually.have.nested.property('rows[0].count', '0')


### PR DESCRIPTION
I think the proper solution to #268 and #269 is to ensure that we wait for the web server to be fully started and accepting incoming requests before we start to clean anything.

When the web server is accepting requests, then the database should be ready and any calls to it should be able to properly create the database.

This also removes a thundering herd problem when multiple instances are brought up simultaneously, as previously they would all start pruning session at once on startup (when auto-pruning was configured), putting unnecessary load on the database.

I think this solution is preferable to #269 as failure to create database is quite a critical condition and shouldn't have to be retried. If the database can't be created, then no web requests can actually be handled.

Previously it could fail because the prune job tried to eagerly create it, but with this PR that will no longer be the case.